### PR TITLE
Add onboarding documentation and describe planned architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # Cem-First
+
+Cem-First, yeni ekibimiz için başlangıç kod temeli olarak hizmet veren hafif bir iskelet projedir. Kodun büyük bölümü henüz inşa edilme aşamasında olsa da, temel dizin yapısı ve geliştirme ilkeleri bu depo içerisinde tanımlanmıştır. Yeni katılanların projeye hızlı adapte olabilmesi için temel bilgileri aşağıda bulabilirsiniz.
+
+## Depo yapısı
+
+```
+.
+├── docs/              # Mimari, onboarding ve diğer rehber dokümanlar
+├── src/               # Uygulama kodu (alan, arayüz ve altyapı katmanları)
+├── tests/             # Otomatik testler ve örnek senaryolar
+└── README.md          # Bu dosya
+```
+
+Detaylı açıklamalar için `docs/` klasöründeki dokümanlara bakabilirsiniz.
+
+## Başlangıç adımları
+1. [docs/onboarding.md](docs/onboarding.md) dosyasını okuyarak kod tabanının genel akışını ve önemli kararları öğrenin.
+2. Geliştirme ortamınızı hazırlarken `docs/architecture.md` dosyasındaki katman açıklamalarını referans alın.
+3. Yeni bir özellik geliştirmeden önce ilgili test senaryolarını `tests/` klasörüne ekleyin ve çalıştırın.
+
+## Katkı ilkeleri
+- Tüm değişiklikler için açıklayıcı commit mesajları kullanın.
+- Kod stili ve mimari kararlar için `docs/architecture.md` dosyasındaki ilkelere uyun.
+- Herhangi bir sorunuz olduğunda öncelikle dokümanlara bakın; gerekirse ekip içindeki mentora ulaşın.
+
+İyi çalışmalar! Proje büyürken bu rehber güncellenecektir.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,42 @@
+# Mimari Özeti
+
+Bu dosya Cem-First projesinde izlenecek katmanlı mimariyi açıklar. Kod tabanı henüz başlangıç aşamasında olsa da, burada belirtilen prensipler gelecekteki geliştirmelerin temelini oluşturacaktır.
+
+## Katmanlar
+
+### 1. API katmanı (`src/api/`)
+- Uygulamanın dış dünya ile konuştuğu katmandır.
+- HTTP uç noktaları, CLI komutları veya planlanan diğer adaptörler burada yer alır.
+- Gelen istekleri doğrular, uygun `core` servislerini çağırır ve yanıtları formatlar.
+- Harici çerçevelere (ör. Express, FastAPI, gRPC) bağlı kodlar sadece bu katmanda tutulur.
+
+### 2. Core katmanı (`src/core/`)
+- Domain kurallarını, iş mantığını ve entity modellerini barındırır.
+- Harici kütüphanelere en az bağımlılık ile yazılır.
+- `api` ve `infrastructure` katmanları tarafından kullanılan servisler, use-case'ler ve domain event'leri bu alanda konumlanır.
+- Testler için öncelikli odak noktasıdır; mantık buraya yazıldığı için birim test yoğunluğu bu katmanda olur.
+
+### 3. Infrastructure katmanı (`src/infrastructure/`)
+- Veritabanı, mesaj kuyruğu, üçüncü parti API çağrıları gibi dış bağımlılıkların adaptörlerini içerir.
+- `core` katmanının ihtiyaç duyduğu port'ların implementasyonlarını sağlar.
+- Konfigürasyon dosyaları, loglama, cache gibi ortak altyapı bileşenleri burada yer alır.
+
+## Veri akışı
+1. Kullanıcı isteği `api` katmanına gelir.
+2. `api`, isteği doğrular ve gerekli verileri `core` katmanına aktarır.
+3. `core`, domain kurallarını çalıştırır ve ihtiyaç duyarsa `infrastructure` katmanındaki adaptörleri kullanır.
+4. Sonuç `api` katmanına döner ve uygun formatta istemciye iletilir.
+
+## Test stratejisi
+- **Birim testleri**: `core` katmanındaki domain kurallarını kapsar.
+- **Entegrasyon testleri**: `infrastructure` adaptörlerinin gerçek servisler veya mocklar ile çalışmasını doğrular.
+- **Uçtan uca testler**: `api` katmanının tüm akışı doğru yönettiğini kontrol eder.
+
+## Kod inceleme kontrol listesi
+- [ ] Yeni kod ilgili katmanda mı yer alıyor?
+- [ ] `core` katmanı doğrudan altyapı detaylarına bağımlı mı? Eğer öyleyse, bağımlılık tersine çevrildi mi?
+- [ ] Giriş doğrulamaları `api` katmanında yapıldı mı?
+- [ ] Yeni davranış için testler eklendi mi?
+- [ ] Dökümantasyon güncellendi mi?
+
+Projede ilerledikçe bu dosya güncellenecek ve yeni kararlar buraya eklenecektir.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,0 +1,27 @@
+# Onboarding Rehberi
+
+Bu doküman, Cem-First kod tabanına yeni katılan geliştiricilerin hızlıca uyum sağlayabilmesi için hazırlanmıştır. Proje henüz erken aşamada olsa da, mimari tercihleri ve iş akışları tanımlanmıştır.
+
+## 1. Genel yapı
+- **Katmanlı mimari**: Kod üç ana katmanda organize edilir: `api` (giriş noktaları), `core` (domain mantığı) ve `infrastructure` (veri erişimi, entegrasyonlar). Her katmanın sorumlulukları [architecture.md](architecture.md) dosyasında detaylandırılmıştır.
+- **Dökümantasyon öncelikli yaklaşım**: Mimari kararlar, katkı süreçleri ve iş akışları `docs/` klasöründe kayıt altındadır. Değişiklik yapılmadan önce ilgili dokümanların güncellenmesi beklenir.
+- **Test odaklı geliştirme**: Yeni özellikler için öncelikle test senaryoları yazılır. Testler `tests/` klasöründe, aynı katman isimlendirmesiyle organize edilir.
+
+## 2. Bilinmesi gereken önemli noktalar
+- **Bağımlılık yönetimi**: `core` katmanı `api` ve `infrastructure` katmanlarından bağımsızdır. Böylece domain mantığı izole ve test edilebilir kalır.
+- **Konfigürasyon**: Ortak konfigürasyonlar `src/infrastructure/config/` altında tutulacak ve ortam değişkenleri ile yönetilecektir.
+- **Hata yönetimi**: Her katmanda anlamlı hata sınıfları kullanılacak; `api` katmanı kullanıcıya dost mesajlar dönerken, `core` ve `infrastructure` katmanları hata loglarını zengin bilgilerle doldurur.
+- **Kod stili**: Takım, açık fonksiyon ve değişken isimlendirmeleri, küçük ve odaklı modüller, kapsamlı yorum yerine kendini ifade eden kod yazımını benimser.
+
+## 3. İlk yapılacaklar
+1. `src/README.md` dosyasındaki katman sorumluluklarını okuyun.
+2. Gereken geliştirme araçlarını (örn. paket yöneticisi, test çalıştırıcı) kurun. Ayrıntılar proje ilerledikçe dokümana eklenecektir.
+3. İlk göreviniz için mentorunuzdan bir `good first issue` isteyin ve ilgili katmanın testlerini nasıl çalıştıracağınızı öğrenin.
+4. Pull request açmadan önce `docs/architecture.md` içinde belirtilen kontrol listesini kullanarak kendi incelemenizi yapın.
+
+## 4. Sonraki adımlar
+- Domain hakkında daha fazla bilgi edinmek için ürün yöneticisi ile kickoff toplantısı planlayın.
+- Veri modellerini ve entegrasyon noktalarını anlamak için gelecekte eklenecek `docs/domain-model.md` ve `docs/integration-guide.md` dokümanlarını takip edin.
+- Otomasyon hattına aşina olmak adına CI ayarları eklendiğinde pipeline sonuçlarını inceleyin.
+
+Herhangi bir sorunuz olursa ekip mentorunuza veya teknik liderinize danışmaktan çekinmeyin.

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,24 @@
+# `src/` Klasörü
+
+Uygulama kodunun tamamı `src/` altında toplanacaktır. Katmanlara göre önerilen dizin yapısı aşağıdadır:
+
+```
+src/
+├── api/             # HTTP, CLI veya diğer giriş noktaları
+├── core/            # Domain modelleri ve iş mantığı
+└── infrastructure/  # Veritabanı, mesaj kuyruğu, üçüncü parti servis adaptörleri
+```
+
+## API katmanı (`api/`)
+- İstemciden gelen istekleri alır, doğrular ve `core` katmanındaki servisleri çağırır.
+- Framework'e özgü bağımlılıkları bu katmanda izole eder.
+
+## Core katmanı (`core/`)
+- Domain kuralları ve use-case implementasyonları burada yaşar.
+- Katman bağımsızlığı için soyut portlar ve interface'ler tanımlanır.
+
+## Infrastructure katmanı (`infrastructure/`)
+- `core` tarafından tanımlanan portların gerçek implementasyonlarını sağlar.
+- Ortak altyapı bileşenleri (örneğin konfigürasyon yükleyicileri, logger, cache) bu bölümde yer alır.
+
+Katmanlar arasında bağımlılık yönü tek yönlüdür: `api -> core <- infrastructure`. `core` katmanı diğer katmanlara doğrudan bağımlı olmamalıdır.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,19 @@
+# Testler
+
+Test stratejisi, kod katmanları ile paralel olarak ilerler.
+
+## Dizin yapısı
+```
+tests/
+├── api/             # Uçtan uca ve sözleşme testleri
+├── core/            # Birim testleri
+└── infrastructure/  # Entegrasyon testleri
+```
+
+## Çalıştırma
+Test otomasyonu henüz projeye eklenmedi. Kurulum tamamlandığında bu dosya güncellenecektir. Şimdilik aşağıdaki prensiplere uyun:
+- Yeni bir özellik eklediğinizde ilgili test dosyalarını oluşturun.
+- Test isimleri açıklayıcı ve başarısız olduğunda neyin bozulduğunu anlatacak şekilde olmalı.
+- Mock kullanımını minimumda tutun; özellikle `core` katmanında saf fonksiyonlar tercih edin.
+
+Güncel süreçler için `docs/onboarding.md` dosyasını takip edin.


### PR DESCRIPTION
## Summary
- expand the main README with repository structure and contribution guidance
- add onboarding and architecture guides that explain the planned layered design
- document the expected layout for application and test code

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e4c27517a48322b51387fc210e4930