### PR TITLE
Create Stremio poster ratings overlay addon

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Copy this file to .env and update the OMDB_API_KEY value.
+# You can request a free key at http://www.omdbapi.com/apikey.aspx
+OMDB_API_KEY=
+
+# Optional: override the default server port (7000)
+# PORT=7000
+
+# Optional: provide a different Cinemeta instance
+# CINEMETA_BASE_URL=https://v3-cinemeta.strem.io

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.env
+npm-debug.log*
+.DS_Store

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Poster Ratings Overlay Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,89 @@
-# Cem-First
+# Poster Ratings Overlay Stremio Add-on
+
+This repository contains a custom [Stremio](https://www.stremio.com/) add-on that decorates every movie and series poster with critic scores from IMDb, Rotten Tomatoes, and Metacritic. The add-on proxies Stremio's public **Cinemeta** catalog, enriches the metadata with fresh ratings from [OMDb](https://www.omdbapi.com/), and exposes them to the Stremio client as colorful poster badges.
+
+## Features
+
+- 🌟 Seamless enrichment of Cinemeta catalogs for both movies and series.
+- 🎯 Poster badges for IMDb, Rotten Tomatoes, and Metacritic so users can compare scores at a glance.
+- ♻️ Transparent caching of rating lookups to avoid hitting external APIs unnecessarily.
+- 🛡️ Graceful fallbacks — if a score is missing, the add-on replaces it with an “N/A” badge instead of failing.
+- ⚙️ Environment-driven configuration (OMDb API key, Cinemeta endpoint, HTTP port).
+
+## Getting Started
+
+### Prerequisites
+
+- **Node.js 18 or newer** (required for the native Fetch API used by the add-on).
+- An **OMDb API key** – request a free personal key at [omdbapi.com/apikey.aspx](http://www.omdbapi.com/apikey.aspx).
+
+### 1. Install dependencies
+
+```bash
+npm install
+```
+
+### 2. Configure environment variables
+
+1. Copy the example configuration:
+   ```bash
+   cp .env.example .env
+   ```
+2. Edit `.env` and set `OMDB_API_KEY` to the key you obtained in the prerequisites.
+3. (Optional) Update `PORT` or `CINEMETA_BASE_URL` if you need a custom setup.
+
+> ℹ️ The project ships with a lightweight `.env` loader, so variables declared in the file are automatically available at runtime without additional dependencies.
+
+### 3. Run the add-on locally
+
+```bash
+npm start
+```
+
+The manifest will be available at [http://localhost:7000/manifest.json](http://localhost:7000/manifest.json) by default. Import this URL into the Stremio desktop or web client to load the catalog.
+
+### 4. Run the health check (optional)
+
+```bash
+npm test
+```
+
+The health check validates that your OMDb key is present and reminds you if optional configuration is missing.
+
+## How Ratings Work
+
+- The add-on mirrors Cinemeta metadata so you retain all existing artwork, trailers, and stream links.
+- For every title, the service calls OMDb using the IMDb ID (preferred) or title/year combination.
+- Retrieved scores are normalized, cached, and injected into:
+  - `behaviorHints.badges` – enables poster overlays.
+  - `ratings` – stores the raw numeric values.
+  - `description` – appends a human-readable summary (helps with clients that do not yet render badges).
+
+If OMDb does not return a given rating, the add-on still adds a badge marked as **N/A**, so each poster clearly displays all three sources.
+
+## Deployment Tips
+
+- Host the add-on on any Node.js-compatible platform (Heroku, Render, Fly.io, etc.).
+- Ensure the `OMDB_API_KEY` environment variable is configured wherever you deploy.
+- Use a reverse proxy with caching (e.g., Cloudflare) to further reduce repeated OMDb calls.
+
+## Validation Checklist
+
+Before sharing the add-on with users:
+
+- [ ] Import the manifest into Stremio and confirm that every poster shows three rating badges.
+- [ ] Trigger search queries, pagination (`skip` extra), and genre filters to ensure metadata enrichment works in all catalog scenarios.
+- [ ] Test movies and series that lack Rotten Tomatoes or Metacritic scores to verify that the “N/A” badges render correctly.
+- [ ] Check the server logs for `Failed to load ratings` messages — if they appear frequently, verify your OMDb API key and request quota.
+
+## Troubleshooting
+
+| Symptom | Possible Cause | Suggested Fix |
+| --- | --- | --- |
+| Badges always show “N/A” | OMDb API key missing or invalid | Confirm the key in `.env` and restart the server. |
+| Catalog loads without posters | Cinemeta base URL overridden incorrectly | Remove or correct `CINEMETA_BASE_URL` in the environment. |
+| Add-on not reachable | Port conflict or blocked by firewall | Change the `PORT` variable and restart, or adjust firewall settings. |
+
+## License
+
+This project is released under the [MIT License](LICENSE) unless stated otherwise.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+require('./src/index');

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "stremio-ratings-overlay",
+  "version": "1.0.0",
+  "description": "Stremio add-on that overlays IMDb, Rotten Tomatoes, and Metacritic scores on posters.",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "dev": "node --watch index.js",
+    "test": "node scripts/health-check.js"
+  },
+  "keywords": [
+    "stremio",
+    "addon",
+    "ratings",
+    "imdb",
+    "rotten tomatoes",
+    "metacritic"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "stremio-addon-sdk": "^1.7.4"
+  }
+}

--- a/scripts/health-check.js
+++ b/scripts/health-check.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+const { loadEnv } = require('../src/utils/env');
+
+loadEnv();
+
+const requiredEnv = ['OMDB_API_KEY'];
+const missing = requiredEnv.filter((key) => !process.env[key]);
+
+if (missing.length) {
+  console.warn(
+    `⚠️  Missing optional environment variable(s): ${missing.join(', ')}.\n` +
+      'The add-on will still run, but Rotten Tomatoes and Metacritic scores require a valid OMDb API key.'
+  );
+} else {
+  console.log('✅ Environment ready – OMDb API key detected.');
+}
+
+console.log('Health check completed.');

--- a/src/cinemeta.js
+++ b/src/cinemeta.js
@@ -1,0 +1,52 @@
+const { URLSearchParams } = require('url');
+
+if (typeof fetch !== 'function') {
+  throw new Error('Global fetch API is not available. Please use Node.js 18 or newer.');
+}
+
+const DEFAULT_BASE_URL = 'https://v3-cinemeta.strem.io';
+const baseUrl = process.env.CINEMETA_BASE_URL || DEFAULT_BASE_URL;
+
+async function fetchJSON(url, options = {}) {
+  const response = await fetch(url, options);
+  if (!response.ok) {
+    const error = new Error(`Request to ${url} failed with status ${response.status}`);
+    error.status = response.status;
+    throw error;
+  }
+  return response.json();
+}
+
+function buildQuery(extra = {}) {
+  const params = new URLSearchParams();
+  Object.entries(extra).forEach(([key, value]) => {
+    if (value === undefined || value === null || value === '') return;
+    if (Array.isArray(value)) {
+      value.forEach((entry) => params.append(key, entry));
+    } else {
+      params.set(key, value);
+    }
+  });
+  const query = params.toString();
+  return query ? `?${query}` : '';
+}
+
+async function fetchCatalog(type, id, extra) {
+  const safeType = encodeURIComponent(type);
+  const safeId = encodeURIComponent(id);
+  const query = buildQuery(extra);
+  const url = `${baseUrl}/catalog/${safeType}/${safeId}.json${query}`;
+  return fetchJSON(url);
+}
+
+async function fetchMeta(type, id) {
+  const safeType = encodeURIComponent(type);
+  const safeId = encodeURIComponent(id);
+  const url = `${baseUrl}/meta/${safeType}/${safeId}.json`;
+  return fetchJSON(url);
+}
+
+module.exports = {
+  fetchCatalog,
+  fetchMeta,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,116 @@
+const { loadEnv } = require('./utils/env');
+
+loadEnv();
+
+const { addonBuilder, serveHTTP } = require('stremio-addon-sdk');
+const { fetchCatalog, fetchMeta } = require('./cinemeta');
+const { getRatingBadges } = require('./ratings');
+
+const manifest = {
+  id: 'org.cem.poster-ratings',
+  version: '1.0.0',
+  name: 'Poster Ratings Overlay',
+  description: 'Shows IMDb, Rotten Tomatoes, and Metacritic scores on top of every poster.',
+  logo: 'https://res.cloudinary.com/stremio/image/upload/v1523456789/addon-ratings.png',
+  resources: ['catalog', 'meta'],
+  types: ['movie', 'series'],
+  idPrefixes: ['tt'],
+  catalogs: [
+    {
+      type: 'movie',
+      id: 'top',
+      name: 'Top Movies',
+      extra: [
+        { name: 'search', isRequired: false },
+        { name: 'genre', isRequired: false },
+        { name: 'skip', isRequired: false },
+      ],
+      extraSupported: ['search', 'genre', 'skip'],
+    },
+    {
+      type: 'series',
+      id: 'top',
+      name: 'Top Series',
+      extra: [
+        { name: 'search', isRequired: false },
+        { name: 'genre', isRequired: false },
+        { name: 'skip', isRequired: false },
+      ],
+      extraSupported: ['search', 'genre', 'skip'],
+    },
+  ],
+  behaviorHints: {
+    configurable: true,
+  },
+};
+
+const builder = new addonBuilder(manifest);
+
+async function enrichMeta(originalMeta) {
+  const meta = {
+    ...originalMeta,
+    behaviorHints: {
+      ...(originalMeta.behaviorHints || {}),
+    },
+  };
+
+  try {
+    const ratingInfo = await getRatingBadges(meta);
+    if (ratingInfo) {
+      meta.behaviorHints.badges = ratingInfo.badges;
+      meta.behaviorHints.badgesLabel = 'Ratings';
+
+      meta.ratings = {
+        ...(meta.ratings || {}),
+        imdb: ratingInfo.values.imdb ?? null,
+        rottenTomatoes: ratingInfo.values.rottenTomatoes ?? null,
+        metacritic: ratingInfo.values.metacritic ?? null,
+      };
+
+      const summary = ratingInfo.badges.map((badge) => badge.text).join(' | ');
+      if (summary) {
+        meta.description = meta.description
+          ? `${meta.description}\n\nRatings: ${summary}`
+          : `Ratings: ${summary}`;
+        meta.ratingSummary = summary;
+      }
+    }
+  } catch (error) {
+    console.warn(`Failed to enrich metadata for ${meta.id}: ${error.message}`);
+  }
+
+  return meta;
+}
+
+builder.defineCatalogHandler(async ({ type, id, extra = {} }) => {
+  try {
+    const response = await fetchCatalog(type, id, extra);
+    const metas = Array.isArray(response.metas) ? response.metas : [];
+    const enriched = await Promise.all(metas.map((meta) => enrichMeta(meta)));
+    return { metas: enriched };
+  } catch (error) {
+    console.error(`Catalog handler error for ${type}/${id}:`, error.message);
+    return { metas: [] };
+  }
+});
+
+builder.defineMetaHandler(async ({ type, id }) => {
+  try {
+    const response = await fetchMeta(type, id);
+    if (!response || !response.meta) {
+      return { meta: null };
+    }
+    const enriched = await enrichMeta(response.meta);
+    return { meta: enriched };
+  } catch (error) {
+    console.error(`Meta handler error for ${type}/${id}:`, error.message);
+    return { meta: null };
+  }
+});
+
+const addonInterface = builder.getInterface();
+const port = Number.parseInt(process.env.PORT, 10) || 7000;
+
+serveHTTP(addonInterface, { port });
+
+console.log(`Poster Ratings Overlay add-on running on http://localhost:${port}/manifest.json`);

--- a/src/ratings.js
+++ b/src/ratings.js
@@ -1,0 +1,158 @@
+const { URLSearchParams } = require('url');
+
+const OMDB_API_KEY = process.env.OMDB_API_KEY;
+const OMDB_BASE_URL = 'https://www.omdbapi.com/';
+
+if (typeof fetch !== 'function') {
+  throw new Error('Global fetch API is not available. Please use Node.js 18 or newer.');
+}
+
+const ratingCache = new Map();
+
+const BADGE_PALETTE = {
+  imdb: '#f5c518',
+  rottenTomatoes: '#fa320a',
+  metacritic: '#2c3e50',
+};
+
+function parseYear(releaseInfo) {
+  if (!releaseInfo) return undefined;
+  const match = `${releaseInfo}`.match(/\d{4}/);
+  return match ? Number.parseInt(match[0], 10) : undefined;
+}
+
+function normaliseNumber(value) {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : undefined;
+  if (typeof value === 'string') {
+    const normalised = value.trim();
+    if (!normalised || normalised === 'N/A') return undefined;
+    const parsed = Number.parseFloat(normalised);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function extractOmdbRatings(payload) {
+  if (!payload) return undefined;
+  const imdbRating = normaliseNumber(payload.imdbRating);
+  let rottenTomatoes;
+  if (Array.isArray(payload.Ratings)) {
+    const entry = payload.Ratings.find((rating) => rating.Source === 'Rotten Tomatoes');
+    if (entry && entry.Value) {
+      const value = entry.Value.replace('%', '');
+      const parsed = Number.parseInt(value, 10);
+      if (Number.isFinite(parsed)) rottenTomatoes = parsed;
+    }
+  }
+  const metacritic = normaliseNumber(payload.Metascore);
+  return {
+    imdb: imdbRating,
+    rottenTomatoes,
+    metacritic,
+  };
+}
+
+function createBadge(label, key, value) {
+  const displayValue = formatBadgeValue(key, value);
+  const text = displayValue ? `${label} ${displayValue}` : `${label} N/A`;
+  return {
+    key,
+    text,
+    color: BADGE_PALETTE[key] || '#1c1c1c',
+    textColor: '#ffffff',
+    backgroundColor: BADGE_PALETTE[key] || '#1c1c1c',
+    available: Boolean(displayValue),
+    rawValue: value ?? null,
+  };
+}
+
+function formatBadgeValue(key, value) {
+  if (value === undefined || value === null) return undefined;
+  if (key === 'imdb') {
+    return Number.isFinite(value) ? value.toFixed(1) : undefined;
+  }
+  if (key === 'rottenTomatoes') {
+    return Number.isFinite(value) ? `${value}%` : undefined;
+  }
+  if (key === 'metacritic') {
+    return Number.isFinite(value) ? `${value}` : undefined;
+  }
+  return `${value}`;
+}
+
+function getCacheKey({ imdbId, title, year }) {
+  if (imdbId) return `imdb:${imdbId}`;
+  if (title) return `title:${title.toLowerCase()}-${year || 'unknown'}`;
+  return undefined;
+}
+
+async function fetchOmdbPayload({ imdbId, title, year, type }) {
+  if (!OMDB_API_KEY) return undefined;
+  const cacheKey = getCacheKey({ imdbId, title, year });
+  if (cacheKey && ratingCache.has(cacheKey)) {
+    return ratingCache.get(cacheKey);
+  }
+  const params = new URLSearchParams({ apikey: OMDB_API_KEY });
+  if (imdbId) {
+    params.set('i', imdbId);
+  } else if (title) {
+    params.set('t', title);
+    if (year) params.set('y', year);
+  } else {
+    return undefined;
+  }
+  if (type) {
+    params.set('type', type === 'series' ? 'series' : 'movie');
+  }
+  const url = `${OMDB_BASE_URL}?${params.toString()}`;
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`OMDb responded with status ${response.status}`);
+    }
+    const data = await response.json();
+    if (data.Response === 'False') {
+      if (cacheKey) ratingCache.set(cacheKey, undefined);
+      return undefined;
+    }
+    const ratings = extractOmdbRatings(data);
+    if (cacheKey) ratingCache.set(cacheKey, ratings);
+    return ratings;
+  } catch (error) {
+    console.warn(`Failed to load ratings from OMDb: ${error.message}`);
+    if (cacheKey) ratingCache.set(cacheKey, undefined);
+    return undefined;
+  }
+}
+
+async function getRatingBadges(meta) {
+  const imdbId = meta.imdb_id || meta.imdbId || (meta.id && meta.id.startsWith('tt') ? meta.id : undefined);
+  const year = meta.year || parseYear(meta.releaseInfo);
+  const title = meta.name || meta.originalTitle;
+
+  const omdbRatings = await fetchOmdbPayload({ imdbId, title, year, type: meta.type });
+
+  const fallbackImdb = normaliseNumber(meta.imdbRating);
+
+  const values = {
+    imdb: omdbRatings && omdbRatings.imdb !== undefined ? omdbRatings.imdb : fallbackImdb,
+    rottenTomatoes: omdbRatings ? omdbRatings.rottenTomatoes : undefined,
+    metacritic: omdbRatings ? omdbRatings.metacritic : undefined,
+  };
+
+  const badges = [
+    createBadge('IMDb', 'imdb', values.imdb),
+    createBadge('RT', 'rottenTomatoes', values.rottenTomatoes),
+    createBadge('MC', 'metacritic', values.metacritic),
+  ];
+
+  return {
+    badges,
+    values,
+  };
+}
+
+module.exports = {
+  getRatingBadges,
+};

--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+
+function loadEnv(envPath = path.resolve(process.cwd(), '.env')) {
+  try {
+    if (!fs.existsSync(envPath)) {
+      return;
+    }
+    const contents = fs.readFileSync(envPath, 'utf8');
+    contents.split(/\r?\n/).forEach((line) => {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) return;
+      const delimiterIndex = trimmed.indexOf('=');
+      if (delimiterIndex === -1) return;
+      const key = trimmed.slice(0, delimiterIndex).trim();
+      const value = trimmed.slice(delimiterIndex + 1).trim();
+      if (!key || Object.prototype.hasOwnProperty.call(process.env, key)) return;
+      process.env[key] = value;
+    });
+  } catch (error) {
+    console.warn(`Unable to load environment variables from ${envPath}: ${error.message}`);
+  }
+}
+
+module.exports = {
+  loadEnv,
+};


### PR DESCRIPTION
## Summary
- scaffold a deployable Stremio add-on that proxies Cinemeta catalogs and enriches metadata with critic score badges
- integrate OMDb-powered rating retrieval with caching, fallbacks, and poster badge formatting for IMDb, Rotten Tomatoes, and Metacritic
- add lightweight env loading, health-check tooling, and documentation covering setup, configuration, and validation steps

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f7f7b144a88322a3cfd4034e9dba24